### PR TITLE
Fixes for GMS 2.3.2

### DIFF
--- a/GMTwerk2.yyp
+++ b/GMTwerk2.yyp
@@ -84,7 +84,7 @@
   ],
   "IncludedFiles": [],
   "MetaData": {
-    "IDEVersion": "2.3.1.542",
+    "IDEVersion": "2.3.2.556",
   },
   "resourceVersion": "1.4",
   "name": "GMTwerk2",

--- a/GMTwerk2.yyp
+++ b/GMTwerk2.yyp
@@ -27,6 +27,7 @@
     {"id":{"name":"GMTwerk_LogValue","path":"scripts/GMTwerk_LogValue/GMTwerk_LogValue.yy",},"order":11,},
     {"id":{"name":"gmtk2_test_whentoggle","path":"scripts/gmtk2_test_whentoggle/gmtk2_test_whentoggle.yy",},"order":8,},
     {"id":{"name":"obj_gmtk2_tester","path":"objects/obj_gmtk2_tester/obj_gmtk2_tester.yy",},"order":1,},
+    {"id":{"name":"gmtk2_test_bugs","path":"scripts/gmtk2_test_bugs/gmtk2_test_bugs.yy",},"order":21,},
     {"id":{"name":"GMTwerk_twerk_waves","path":"scripts/GMTwerk_twerk_waves/GMTwerk_twerk_waves.yy",},"order":17,},
     {"id":{"name":"gmtk2_test_while","path":"scripts/gmtk2_test_while/gmtk2_test_while.yy",},"order":6,},
     {"id":{"name":"gmtk2_test_basics","path":"scripts/gmtk2_test_basics/gmtk2_test_basics.yy",},"order":3,},

--- a/scripts/GMTwerk_classes/GMTwerk_classes.gml
+++ b/scripts/GMTwerk_classes/GMTwerk_classes.gml
@@ -122,26 +122,40 @@ function GMTwerkBank() constructor {
 	///@param {real} time The amount of time to elapse for this tick
 	///@desc Process all actors in the linked list given the elapsed time since last tick
 	static act = function(steps, microseconds) {
+		var needCleanup = false;
 		// For every node in the linked list
 		var previousNode = undefined;
 		var currentNode = _head;
 		while (!is_undefined(currentNode)) {
+			// Act
 			var currentActor = currentNode[0];
-			// If the actor is done already or ended up done after acting, unlink it
-			if (currentActor.state <= GMTWERK_STATE.DONE || currentActor.act(currentActor.deltaTime ? (is_undefined(microseconds) ? delta_time : microseconds) : (is_undefined(steps) ? GMTWERK_DEFAULT_STEP_SPEED : steps)) <= GMTWERK_STATE.DONE) {
-				if (is_undefined(previousNode)) {
-					_head = currentNode[1];
-				} else {
-					previousNode[@1] = currentNode[1];
-				}
-				--size;
-			}
-			// Otherwise, keep it anchored in the list
-			else {
-				previousNode = currentNode;
-			}
+			needCleanup = currentActor.act(currentActor.deltaTime ? (is_undefined(microseconds) ? delta_time : microseconds) : (is_undefined(steps) ? GMTWERK_DEFAULT_STEP_SPEED : steps)) <= GMTWERK_STATE.DONE || needCleanup;
 			// Go to next
 			currentNode = currentNode[1];
+		}
+		// Clean finished nodes if any new ones cropped up
+		if (needCleanup) {
+			previousNode = undefined;
+			currentNode = _head;
+			// For every node in the linked list
+			while (!is_undefined(currentNode)) {
+				// If the actor is done already or ended up done after acting, unlink it
+				var currentActor = currentNode[0];
+				if (currentActor.state <= GMTWERK_STATE.DONE) {
+					if (_head == currentNode) {
+						_head = currentNode[1];
+					} else {
+						previousNode[@1] = currentNode[1];
+					}
+					--size;
+				}
+				// Otherwise, keep it anchored in the list
+				else {
+					previousNode = currentNode;
+				}
+				// Go to next
+				currentNode = currentNode[1];
+			}
 		}
 	};
 

--- a/scripts/GMTwerk_classes/GMTwerk_classes.gml
+++ b/scripts/GMTwerk_classes/GMTwerk_classes.gml
@@ -86,8 +86,10 @@ function GMTwerkActor() constructor {
 	///@param {array} opts Alternating array of parameter names and values
 	///@desc Include the given options into the actor
 	static includeOpts = function(params) {
-		for (var i = array_length(params)-2; i >= 0; i -= 2) {
-			variable_struct_set(self, params[i], params[i+1]);
+		if (is_array(params)) { // BUGFIX: 2.3.2.420 - Catch argument_count failure
+			for (var i = array_length(params)-2; i >= 0; i -= 2) {
+				variable_struct_set(self, params[i], params[i+1]);
+			}
 		}
 	};
 

--- a/scripts/GMTwerk_classes/GMTwerk_classes.gml
+++ b/scripts/GMTwerk_classes/GMTwerk_classes.gml
@@ -90,6 +90,9 @@ function GMTwerkActor() constructor {
 			for (var i = array_length(params)-2; i >= 0; i -= 2) {
 				variable_struct_set(self, params[i], params[i+1]);
 			}
+			if (!is_undefined(bank)) {
+				bank.add(self);
+			}
 		}
 	};
 
@@ -100,6 +103,7 @@ function GMTwerkActor() constructor {
 	onDone = noop;
 	onLost = noop;
 	owner = noone;
+	bank = undefined;
 	deltaTime = GMTWERK_DEFAULT_TIME_MODE;
 	static onAct = noop; //Overridden by children
 }
@@ -197,16 +201,18 @@ function GMTwerkArrayIterator(_array) constructor {
 ///@param {GMTwerkActor} actor The actor to insert into the main bank
 ///@desc Insert an actor into the main bank, creating the daemon if it doesn't exist already
 function __gmtwerk_insert__(actor) {
-	if (id && variable_instance_exists(id, "__gmtwerk_self_host__")) {
-		__gmtwerk_self_host__.add(actor);
-	} else {
-		if (!instance_exists(__gmtwerk_host__)) {
-			instance_create_depth(0, 0, 0, __gmtwerk_host__);
+	if (is_undefined(actor.bank)) {
+		if (id && variable_instance_exists(id, "__gmtwerk_self_host__")) {
+			__gmtwerk_self_host__.add(actor);
+		} else {
+			if (!instance_exists(__gmtwerk_host__)) {
+				instance_create_depth(0, 0, 0, __gmtwerk_host__);
+			}
+			if (id) {
+				actor.owner = id;
+			}
+			__gmtwerk_host__.__twerks__.add(actor);
 		}
-		if (id) {
-			actor.owner = id;
-		}
-		__gmtwerk_host__.__twerks__.add(actor);
 	}
 }
 

--- a/scripts/gmtk2_test_all/gmtk2_test_all.gml
+++ b/scripts/gmtk2_test_all/gmtk2_test_all.gml
@@ -20,6 +20,7 @@ function gmtk2_test_all() {
 	gmtk2_test_twerk_wave();
 	gmtk2_test_twerk();
 	gmtk2_test_workflow();
+	gmtk2_test_bugs();
 	/** ^^ Place tests here ^^ **/
 	
 	var timeB = current_time;

--- a/scripts/gmtk2_test_bugs/gmtk2_test_bugs.gml
+++ b/scripts/gmtk2_test_bugs/gmtk2_test_bugs.gml
@@ -12,12 +12,14 @@ function gmtk2_test_github_1() {
 		bgx: -1,
 		mgx: -1,
 	};
-	_subject.bank.add(new ItineraryActor(int64(12), [
-		[int64(12), method(_subject, function() { bank.add(new TweenActor(StructVar("bgx", self).set(56), 0, int64(30), ["type", te_cubic_out])); })],
-		[int64(12), method(_subject, function() { bank.add(new TweenActor(StructVar("mgx", self).set(56), 0, int64(30), ["type", te_cubic_out])); })],
-	]));
+	Itinerary(int64(12), [
+		[int64(12), method(_subject, function() { Tween(StructVar("bgx", self).set(56), 0, int64(30), ["type", te_cubic_out, "bank", bank]); })],
+		[int64(12), method(_subject, function() { Tween(StructVar("mgx", self).set(56), 0, int64(30), ["type", te_cubic_out, "bank", bank]); })],
+	], [
+		"bank", _subject.bank
+	]);
 	repeat (60) {
-		_subject.bank.act(1, 1000000 div 60);
+		_subject.bank.act(1);
 	}
 	assert_equal(_subject.bgx, 0, "GitHub #1: bgx wrong");
 	assert_equal(_subject.mgx, 0, "GitHub #1: mgx wrong");

--- a/scripts/gmtk2_test_bugs/gmtk2_test_bugs.gml
+++ b/scripts/gmtk2_test_bugs/gmtk2_test_bugs.gml
@@ -1,0 +1,24 @@
+///@func gmtk2_test_bugs()
+///@desc Regression tests against reported bugs
+function gmtk2_test_bugs() {
+	gmtk2_test_github_1();
+}
+
+///@func gmtk2_test_github_1()
+///@desc See: https://github.com/dicksonlaw583/GMTwerk2/issues/1
+function gmtk2_test_github_1() {
+	var _subject = {
+		bank: new GMTwerkBank(),
+		bgx: -1,
+		mgx: -1,
+	};
+	_subject.bank.add(new ItineraryActor(int64(12), [
+		[int64(12), method(_subject, function() { bank.add(new TweenActor(StructVar("bgx", self).set(56), 0, int64(30), ["type", te_cubic_out])); })],
+		[int64(12), method(_subject, function() { bank.add(new TweenActor(StructVar("mgx", self).set(56), 0, int64(30), ["type", te_cubic_out])); })],
+	]));
+	repeat (60) {
+		_subject.bank.act(1, 1000000 div 60);
+	}
+	assert_equal(_subject.bgx, 0, "GitHub #1: bgx wrong");
+	assert_equal(_subject.mgx, 0, "GitHub #1: mgx wrong");
+}

--- a/scripts/gmtk2_test_bugs/gmtk2_test_bugs.yy
+++ b/scripts/gmtk2_test_bugs/gmtk2_test_bugs.yy
@@ -1,0 +1,12 @@
+{
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "GMTwerk2_test",
+    "path": "folders/Libraries_test/GMTwerk2_test.yy",
+  },
+  "resourceVersion": "1.0",
+  "name": "gmtk2_test_bugs",
+  "tags": [],
+  "resourceType": "GMScript",
+}


### PR DESCRIPTION
- Worked around `<opts>` parameter crash on GMS 2.3.2 (YoYo Marketplace)
- Fixed `GMTwerkBank`'s self-cleaning routine to avoid accidentally dropping actors that should still be active (GitHub #1)